### PR TITLE
Add support for Nova translatable and user locale

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,10 @@
         "php": "^8.1",
         "spatie/laravel-package-tools": "^1.14.0",
         "illuminate/contracts": "^10.0",
-        "outl1ne/nova-inline-text-field": "dev-salah"
+        "outl1ne/nova-inline-text-field": "dev-salah",
+        "spatie/nova-translatable": "^3.1",
+        "laravel/nova": "^4.0"
+
     },
     "require-dev": {
         "laravel/pint": "^1.0",
@@ -89,6 +92,10 @@
         {
             "type": "vcs",
             "url": "https://github.com/Elshaden/nova-inline-text-field.git"
+        },
+        {
+            "type": "composer",
+            "url": "https://nova.laravel.com"
         }
     ],
     "minimum-stability": "dev",

--- a/database/migrations/add_local_to_users_table.php.stub
+++ b/database/migrations/add_local_to_users_table.php.stub
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+          Schema::table('users', function (Blueprint $table) {
+
+            $table->string('locale')->default('en');
+
+          });
+    }
+
+      /**
+         * Reverse the migrations.
+         */
+        public function down(): void
+        {
+           Schema::table('users', function (Blueprint $table) {
+
+            $table->dropColumn('locale');
+
+           });
+        }
+};

--- a/src/NovaLocalizationServiceProvider.php
+++ b/src/NovaLocalizationServiceProvider.php
@@ -2,10 +2,15 @@
 
 namespace Centrust\NovaLocalization;
 
+use Illuminate\Http\Request;
+use Laravel\Nova\Events\ServingNova;
+use Laravel\Nova\Menu\Menu;
+use Laravel\Nova\Menu\MenuItem;
+use Laravel\Nova\Nova;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 use Centrust\NovaLocalization\Commands\NovaLocalizationCommand;
-
+use Spatie\NovaTranslatable\Translatable;
 class NovaLocalizationServiceProvider extends PackageServiceProvider
 {
     public function configurePackage(Package $package): void
@@ -21,5 +26,32 @@ class NovaLocalizationServiceProvider extends PackageServiceProvider
             ->hasViews()
             ->hasMigration('create_nova_localization_table')
             ->hasCommand(NovaLocalizationCommand::class);
+    }
+
+    public function bootingPackage()
+    {
+        Translatable::defaultLocales(['en', 'ar']);
+        Nova::serving(function (ServingNova $event) {
+            $Locale = auth()->user()?->locale ?? Null;
+            if ($Locale) {
+                app()->setLocale($Locale);
+                $event->request->setLocale($Locale);
+            }else{
+                if(auth()->check()) {
+                      auth()->user()->update(['locale' => app()->getLocale()]);
+                }
+            }
+            if (app()->getLocale() == 'ar') {
+                Nova::enableRTL();
+            }
+        });
+        Nova::userMenu(function (Request $request, Menu $menu) {
+
+            $language = app()->getLocale() == 'ar' ? 'en' : 'ar';
+
+            $menu->prepend(MenuItem::externalLink(app()->getLocale() == 'ar' ? 'English' : 'عربي', '/change-language/' . $language));
+
+            return $menu;
+        });
     }
 }


### PR DESCRIPTION
In this commit, Nova translatable package was added to the dependencies in composer.json. Also, a locale field was added to the 'users' table for storing users' language preferences. User locale is now updated based on authentication status and language setting in the NovaLocalizationServiceProvider file. Furthermore, right-to-left support for Nova was enabled for the Arabic language.